### PR TITLE
Fix log path quoting and implement SSH macro

### DIFF
--- a/ssh_log.ttl
+++ b/ssh_log.ttl
@@ -1,1 +1,42 @@
+;; teraterm用マクロ　ssh接続し、ログの取得を実施
 
+;; 接続先サーバ・ユーザ名・パスワード設定
+HOSTADDR = 'IPアドレス'
+USERNAME = 'ユーザー名'
+PASSWORD = 'パスワード'
+
+;; ログ保存先指定
+LOGSPATH = 'C:\\logs\\'
+
+;;ログフォルダ作成実行
+;;すでにフォルダがあってもコマンドが発行されるが、問題なし
+EXECMD = 'cmd /c md "'
+strconcat EXECMD LOGSPATH
+strconcat EXECMD '"'
+exec EXECMD
+
+;; ログファイル名の設定
+getdate LOG_NAME 'teraterm_%Y%m%d_%H%M%S_&h.log'
+FULLPATH = LOGSPATH
+strconcat FULLPATH LOG_NAME
+
+;==============================================
+;; コマンド組立て
+COMMAND = HOSTADDR
+strconcat COMMAND ':22 /ssh /T=1'
+
+;; サーバ接続
+connect COMMAND
+
+;; ログイン情報応答（ユーザ名・パスワード）
+wait 'login:'
+sendln USERNAME
+wait 'Password:'
+sendln PASSWORD
+
+;; ログ取得開始
+logopen FULLPATH 0 1 1 1 1
+
+
+;; マクロ終了
+end

--- a/telnet_log.ttl
+++ b/telnet_log.ttl
@@ -10,8 +10,9 @@ LOGSPATH = 'C:\logs\'
 
 ;;ログフォルダ作成実行
 ;;すでにフォルダがあってもコマンドが発行されるが、問題なし
-EXECMD = 'cmd /c md '
+EXECMD = 'cmd /c md "'
 strconcat EXECMD LOGSPATH
+strconcat EXECMD '"'
 exec EXECMD
 
 ;; ログファイル名の設定


### PR DESCRIPTION
## Summary
- fix log directory creation in telnet macro to handle paths with spaces
- implement missing ssh logging macro

## Testing
- `echo "no tests" && true`

------
https://chatgpt.com/codex/tasks/task_e_684148784b9c8320851988487eb5329f